### PR TITLE
单次请求交互之后关闭sse连接

### DIFF
--- a/src/main/java/com/unfbx/chatgptsteamoutput/listener/OpenAISSEEventSourceListener.java
+++ b/src/main/java/com/unfbx/chatgptsteamoutput/listener/OpenAISSEEventSourceListener.java
@@ -50,6 +50,8 @@ public class OpenAISSEEventSourceListener extends EventSourceListener {
                     .id("[DONE]")
                     .data("[DONE]")
                     .reconnectTime(3000));
+            // 传输完成后自动关闭sse
+            sseEmitter.complete();
             return;
         }
         ObjectMapper mapper = new ObjectMapper();


### PR DESCRIPTION
当前sse连接只会在超时或异常情况下关闭连接；修改为在OpenAI数据传输结束后自动关闭连接